### PR TITLE
Max/detached head

### DIFF
--- a/doltpy_integrations/metaflow/__init__.py
+++ b/doltpy_integrations/metaflow/__init__.py
@@ -1,1 +1,1 @@
-from .dolt import DoltDT, DoltConfig
+from .dolt import DoltDT, DoltConfig, detach_head


### PR DESCRIPTION
Setting head was not working correctly.

The new context manager correctly checks out the appropriate branch during a query.

There are edge-cases where a failure/exit will leave a user might be left on a detached head branch, for example if they were to manipulate the branch in the body of their custom SQL query.